### PR TITLE
Switch to FD.o SDK 19.08

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -1,7 +1,7 @@
 id: net.lutris.Lutris
 sdk: org.freedesktop.Sdk
 runtime: org.freedesktop.Platform
-runtime-version: "18.08"
+runtime-version: "19.08beta"
 command: lutris
 rename-icon: lutris
 copy-icon: true

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -33,17 +33,17 @@ finish-args:
 add-extensions:
   org.freedesktop.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
-    version: "18.08"
+    version: "19.08beta"
 
   org.freedesktop.Platform.Compat.i386.Debug:
     directory: lib/debug/lib/i386-linux-gnu
-    version: "18.08"
+    version: "19.08beta"
     no-autodownload: true
 
   org.freedesktop.Platform.GL32:
     directory: lib/i386-linux-gnu/GL
     version: "1.4"
-    versions: "18.08;1.4"
+    versions: "19.08beta;1.4"
     subdirectories: true
     no-autodownload: true
     autodelete: false


### PR DESCRIPTION
FD.o SDK 19.08 beta is available now. We need it for multiarch builds.