### PR TITLE
Workaround missing lib/i386-linux-gnu/GL directory

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -41,7 +41,8 @@ add-extensions:
     no-autodownload: true
 
   org.freedesktop.Platform.GL32:
-    directory: lib/i386-linux-gnu/GL
+    #FIXME set it back to lib/i386-linux-gnu/GL
+    directory: lib32/GL
     version: "1.4"
     versions: "19.08beta;1.4"
     subdirectories: true
@@ -607,6 +608,7 @@ modules:
     buildsystem: simple
     build-commands:
       - mkdir -p /app/lib/i386-linux-gnu
+      - mkdir -p /app/lib32/GL
       - install -Dm644 ld.so.conf -t /app/etc/
       - mkdir -p /app/runners
     sources:

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -609,6 +609,8 @@ modules:
     build-commands:
       - mkdir -p /app/lib/i386-linux-gnu
       - mkdir -p /app/lib32/GL
+      - mkdir -p /app/share/vulkan/
+      - ln -sr /app/lib32/GL/vulkan/icd.d /app/share/vulkan/icd.d
       - install -Dm644 ld.so.conf -t /app/etc/
       - mkdir -p /app/runners
     sources:


### PR DESCRIPTION
Temporarily mount the `org.freedesktop.Platform.GL32` extension to `/app/lib32/GL` instead of `/app/lib/i386-linux-gnu/GL`.
Fixes #41.
Must be reverted once the `/app/lib/i386-linux-gnu/GL` directory is added in `org.gnome.Platform.Compat.i386` extension.
This breaks 32-bit Vulkan for non-Nvidia.