### PR TITLE
Remove dconf permissions

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -16,9 +16,6 @@ finish-args:
   - --allow=devel
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.gnome.Mutter.DisplayConfig
-  - --talk-name=ca.desrt.dconf
-  - --filesystem=xdg-run/dconf
-  - --filesystem=xdg-config/dconf:ro
   - --filesystem=~/Games:create
   - --filesystem=xdg-desktop
   - --filesystem=xdg-documents


### PR DESCRIPTION
AFAIK it's not needed anymore for Gnome 3.34