### PR TITLE
Update merge-dirs for GL32 extension

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -45,7 +45,7 @@ add-extensions:
     no-autodownload: true
     autodelete: false
     add-ld-path: lib
-    merge-dirs: vulkan/icd.d;glvnd/egl_vendor.d;OpenCL/vendors
+    merge-dirs: vulkan/icd.d;glvnd/egl_vendor.d;OpenCL/vendors;lib/dri;lib/d3d;vulkan/explicit_layer.d
     download-if: active-gl-driver
     enable-if: active-gl-driver
 

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -52,7 +52,6 @@ add-extensions:
   net.lutris.Lutris.Runner:
     directory: runners
     subdirectories: true
-    add-ld-path: lib
     merge-dirs: bin
 
 sdk-extensions:


### PR DESCRIPTION
Match current merge-dirs list of runtime's GL extension.
Hope this fixes #20.