### PR TITLE
Bundle Wine

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -407,8 +407,8 @@ modules:
     sources: &wine_sources
       - type: git
         url: "https://github.com/lutris/wine.git"
-        branch: lutris-nofshack-4.18
-        commit: 5744890c2c42700166db772d8bd17e8bbe8e8a0e
+        branch: lutris-nofshack-4.19
+        commit: d6604ea9f28b54fbf8d6c3722f118241a8313ede
     cleanup: &wine_cleanup
       - /bin/function_grep.pl
       - /bin/widl

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -408,7 +408,7 @@ modules:
       - type: git
         url: "https://github.com/lutris/wine.git"
         branch: lutris-nofshack-4.19
-        commit: d6604ea9f28b54fbf8d6c3722f118241a8313ede
+        commit: b34f4a384c4591e6ec9575787e8093ad7675b132
     cleanup: &wine_cleanup
       - /bin/function_grep.pl
       - /bin/widl

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -52,6 +52,7 @@ add-extensions:
   net.lutris.Lutris.Runner:
     directory: runners
     subdirectories: true
+    no-autodownload: true
     merge-dirs: bin
 
 sdk-extensions:
@@ -373,6 +374,80 @@ modules:
     buildsystem: cmake-ninja
     config-opts: *faudio_config_opts
     sources: *faudio_sources
+
+  # Wine In Not Emulator
+
+  - name: wine
+    build-options:
+      libdir: /app/lib
+      config-opts:
+        - --enable-win64
+    config-opts: &wine_common_opts
+      - --disable-win16
+      - --disable-tests
+      - --with-x
+      - --with-pulse
+      - --with-dbus
+      - --without-hal
+      - --without-oss
+    make-install-args: &wine_common_make_install_args
+      - LDCONFIG=/bin/true
+      - STRIP=/bin/true
+      - UPDATE_DESKTOP_DATABASE=/bin/true
+    post-install:
+      - |
+        case $FLATPAK_ARCH in
+          x86_64)
+            mv ${FLATPAK_DEST}/bin/wineserver{,64}
+          ;;
+          i386)
+            mv ${FLATPAK_DEST}/bin/wineserver{,32}
+          ;;
+        esac
+    sources: &wine_sources
+      - type: git
+        url: "https://github.com/lutris/wine.git"
+        branch: lutris-4.16
+        commit: d67da44865e4818e6e477a70e7e85dc05186bf96
+    cleanup: &wine_cleanup
+      - /bin/function_grep.pl
+      - /bin/widl
+      - /bin/winebuild
+      - /bin/winecpp
+      - /bin/winedump
+      - /bin/wineg++
+      - /bin/winegcc
+      - /bin/winemaker
+      - /bin/wmc
+      - /bin/wrc
+      - /lib*/wine/*.def
+
+  - name: wine-32bit
+    only-arches:
+      - x86_64
+    build-options:
+      arch:
+        x86_64: *compat_i386_opts
+    config-opts: *wine_common_opts
+    make-install-args: *wine_common_make_install_args
+    post-install:
+      - mv ${FLATPAK_DEST}/bin/wineserver{,32}
+    sources: *wine_sources
+    cleanup: *wine_cleanup
+
+
+  - name: wine-bundle-setup
+    buildsystem: simple
+    build-commands:
+      - |
+        case $FLATPAK_ARCH in
+          x86_64)
+            ln -s wineserver64 ${FLATPAK_DEST}/bin/wineserver
+          ;;
+          i386)
+            ln -s wineserver32 ${FLATPAK_DEST}/bin/wineserver
+          ;;
+        esac
 
   # Multilib dependencies for native games and runners
 

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -407,8 +407,8 @@ modules:
     sources: &wine_sources
       - type: git
         url: "https://github.com/lutris/wine.git"
-        branch: lutris-4.16
-        commit: d67da44865e4818e6e477a70e7e85dc05186bf96
+        branch: lutris-nofshack-4.18
+        commit: 5744890c2c42700166db772d8bd17e8bbe8e8a0e
     cleanup: &wine_cleanup
       - /bin/function_grep.pl
       - /bin/widl

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -408,7 +408,7 @@ modules:
       - type: git
         url: "https://github.com/lutris/wine.git"
         branch: lutris-nofshack-4.19
-        commit: b34f4a384c4591e6ec9575787e8093ad7675b132
+        commit: 2f231e8744cd958b16e58fe7c96a43610fef9c82
     cleanup: &wine_cleanup
       - /bin/function_grep.pl
       - /bin/widl

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -407,8 +407,8 @@ modules:
     sources: &wine_sources
       - type: git
         url: "https://github.com/lutris/wine.git"
-        branch: lutris-nofshack-4.19
-        commit: 2f231e8744cd958b16e58fe7c96a43610fef9c82
+        branch: lutris-4.20
+        commit: 08aea31cd787455221f038cd91fc509b167e0fa5
     cleanup: &wine_cleanup
       - /bin/function_grep.pl
       - /bin/widl


### PR DESCRIPTION
Build Wine as a part of the app bundle.
Since flathub/flathub#1060 doesn't seem to be going to be accepted anytime soon, bundling Wine seems a solution to provide wine runner.
This drastically increases size of the bundle, about from 60Mb to 580Mb.