### PR TITLE
Make Lutris Run Again

### DIFF
--- a/lutris_pr_2558.patch
+++ b/lutris_pr_2558.patch
@@ -1,0 +1,23 @@
+From 9e03995b0ae270eb8901efaca248cd685de772cf Mon Sep 17 00:00:00 2001
+From: Stefan Strogin <steils@gentoo.org>
+Date: Tue, 31 Dec 2019 03:22:26 +0200
+Subject: [PATCH] Call the correct method for creating TreeModelSort (Closes
+ #2554)
+
+---
+ lutris/gui/views/store.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lutris/gui/views/store.py b/lutris/gui/views/store.py
+index 9bab31587..9e843e9e4 100644
+--- a/lutris/gui/views/store.py
++++ b/lutris/gui/views/store.py
+@@ -140,7 +140,7 @@ def __init__(
+         self.prevent_sort_update = False  # prevent recursion with signals
+         self.modelfilter = self.store.filter_new()
+         self.modelfilter.set_visible_func(self.filter_view)
+-        self.modelsort = Gtk.TreeModelSort.sort_new_with_model(self.modelfilter)
++        self.modelsort = Gtk.TreeModelSort.new_with_model(self.modelfilter)
+         self.modelsort.connect("sort-column-changed", self.on_sort_column_changed)
+         self.modelsort.set_sort_func(sort_col, sort_func, sort_col)
+         self.sort_view(sort_key, sort_ascending)

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -89,6 +89,8 @@ modules:
       - type: git
         url: "https://github.com/lutris/lutris.git"
         tag: v0.5.4
+      - type: patch
+        path: ./lutris_pr_2558.patch
     modules:
       - name: gnome-desktop
         buildsystem: meson


### PR DESCRIPTION
Fixes: https://github.com/flathub/net.lutris.Lutris/issues/91

This fixes the `AttributeError: type object 'TreeModelSort' has no attribute 'sort_new_with_model'` error (https://github.com/flathub/net.lutris.Lutris/issues/91 and https://github.com/lutris/lutris/issues/2554) by applying the fix from https://github.com/lutris/lutris/pull/2558 as a patch (you can get a patch from a PR by adding `.patch` at the end of the url).

Once the change introduced in https://github.com/lutris/lutris/pull/2558 is included in a new Lutris version, the changes made in this PR can be reverted, when upgrading to that new Lutris version.
This version will probably be `0.5.5` (see https://github.com/lutris/lutris/issues/2554). 