### PR TITLE
Update GNOME runtime to 3.38

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -1,7 +1,7 @@
 id: net.lutris.Lutris
 sdk: org.gnome.Sdk
 runtime: org.gnome.Platform
-runtime-version: "3.36"
+runtime-version: "3.38"
 command: lutris
 rename-icon: lutris
 copy-icon: true
@@ -30,17 +30,17 @@ finish-args:
 add-extensions:
   org.gnome.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
-    version: "3.36"
+    version: "3.38"
 
   org.gnome.Platform.Compat.i386.Debug:
     directory: lib/debug/lib/i386-linux-gnu
-    version: "3.36"
+    version: "3.38"
     no-autodownload: true
 
   org.freedesktop.Platform.GL32:
     directory: lib/i386-linux-gnu/GL
     version: "1.4"
-    versions: "19.08;1.4"
+    versions: "20.08;1.4"
     subdirectories: true
     no-autodownload: true
     autodelete: false
@@ -93,8 +93,8 @@ modules:
         buildsystem: meson
         sources:
           - type: archive
-            url: "https://download.gnome.org/sources/gnome-desktop/3.36/gnome-desktop-3.36.4.tar.xz"
-            sha256: 007bbd48c1ca2fcb184713c923174c1d4328c3e33a2271ca536bdd3b71229bc6
+            url: "https://download.gnome.org/sources/gnome-desktop/3.38/gnome-desktop-3.38.0.tar.xz"
+            sha256: 089dbbe3c66fe5575659a4a385d5d4bbd99cf637034df317f21cf586b5dd6b90
 
       - name: python-evdev
         buildsystem: simple
@@ -193,16 +193,16 @@ modules:
   - name: vkd3d
     sources: &vkd3d_sources
       - type: archive
-        url: "https://dl.winehq.org/vkd3d/source/vkd3d-1.1.tar.xz"
-        sha256: 495adc61cc80c65d54b2f5b52092ea05d3797cc2c17a610f0fc98457d2f56ab6
+        url: "https://dl.winehq.org/vkd3d/source/vkd3d-1.2.tar.xz"
+        sha256: b04b030fcbf0f2dacc933c76c74b449bffef1fc1a18d50254ef1ad3e380df96b
     modules:
 
       - name: SPIRV-Headers
         buildsystem: cmake-ninja
         sources:
           - type: archive
-            url: "https://github.com/KhronosGroup/SPIRV-Headers/archive/1.4.1.tar.gz"
-            sha256: a244f0629f75eb450e090cd773d30e22367cb231e964c7492588eb9000201fd1
+            url: "https://github.com/KhronosGroup/SPIRV-Headers/archive/1.5.3.tar.gz"
+            sha256: eece8a9e147d37997d425d5d2eeb2e757ad25adc30d6651467094f3b18609b5a
 
   - name: vkd3d-32bit
     build-options:
@@ -277,7 +277,7 @@ modules:
     sources:
       - type: git
         url: "https://github.com/KhronosGroup/OpenCL-Headers.git"
-        commit: 96f5bde69064a7f94012b40fffd66ac5508977da
+        commit: c5a4bbeabb10d8ed3d1c651b93aa31737bc473dd
 
 
   - name: libpcap
@@ -303,8 +303,8 @@ modules:
       - --disable-qvidcap
     sources: &v4l2_sources
       - type: archive
-        url: "https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.18.0.tar.bz2"
-        sha256: 6cb60d822eeed20486a03cc23e0fc65956fbc1e85e0c1a7477f68bbd9802880d
+        url: "https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.20.0.tar.bz2"
+        sha256: 956118713f7ccb405c55c7088a6a2490c32d54300dd9a30d8d5008c28d3726f7
 
   - name: v4l2-utils-32bit
     build-options:
@@ -379,8 +379,8 @@ modules:
       - -DFFMPEG=ON
     sources: &faudio_sources
       - type: archive
-        url: "https://github.com/FNA-XNA/FAudio/archive/20.07.tar.gz"
-        sha256: 65f63726a06083871abd60e69d94f1df2d9f6f4dea8d4d627b0f5d87847deacc
+        url: "https://github.com/FNA-XNA/FAudio/archive/20.09.tar.gz"
+        sha256: 375d12ba57f507b95e030926fd08308029b38af883d0524583a2d5d8fe65168b
 
   - name: FAudio-32bit
     build-options:
@@ -530,6 +530,8 @@ modules:
       - type: archive
         url: "https://downloads.sourceforge.net/p7zip/p7zip_16.02_src_all.tar.bz2"
         sha256: 5eb20ac0e2944f6cb9c2d51dd6c4518941c185347d4089ea89087ffdd6e2341f
+      - type: patch
+        path: patches/p7zip/gcc10.patch
       - type: shell
         only-arches:
           - "x86_64"

--- a/patches/p7zip/gcc10.patch
+++ b/patches/p7zip/gcc10.patch
@@ -1,0 +1,20 @@
+--- a/CPP/Windows/ErrorMsg.cpp  2020-05-28 00:35:02.729896917 +0200
++++ b/CPP/Windows/ErrorMsg.cpp  2020-05-28 00:40:01.676442629 +0200
+@@ -13,7 +13,7 @@
+   const char * txt = 0;
+   AString msg;
+
+-  switch(errorCode) {
++  switch(HRESULT(errorCode)) {
+     case ERROR_NO_MORE_FILES   : txt = "No more files"; break ;
+     case E_NOTIMPL             : txt = "E_NOTIMPL"; break ;
+     case E_NOINTERFACE         : txt = "E_NOINTERFACE"; break ;
+@@ -43,7 +43,7 @@
+   const char * txt = 0;
+   AString msg;
+
+-  switch(messageID) {
++  switch(HRESULT(messageID)) {
+     case ERROR_NO_MORE_FILES   : txt = "No more files"; break ;
+     case E_NOTIMPL             : txt = "E_NOTIMPL"; break ;
+     case E_NOINTERFACE         : txt = "E_NOINTERFACE"; break ;


### PR DESCRIPTION
I have only tested that lutris actually runs with output
```
2020-09-29 02:20:31,748: Couldn't find a terminal emulator.
2020-09-29 02:20:31,940: MAME XML generation launched in the background, not returning anything this time
2020-09-29 02:20:31,941: Getting full game list from MAME...
2020-09-29 02:20:31,945: MAME isn't installed, can't retrieve systems list.
2020-09-29 02:20:31,988: Migrating games field humblestoreid
2020-09-29 02:20:32,053: Running Lutris 0.5.7.1
2020-09-29 02:20:32,053: Running migration: d9vk_to_dxvk
2020-09-29 02:20:32,055: Running migration: fix_playtime_type
2020-09-29 02:20:32,065: Running migration: mess_to_mame
2020-09-29 02:20:32,070: Using Intel Open Source Technology Center
2020-09-29 02:20:32,070: Running Mesa driver 20.1.5 on Mesa DRI Intel(R) UHD Graphics 620 (KBL GT2) (0x5917)
2020-09-29 02:20:32,071: GPU: 8086:5917 17AA:225D using i915 drivers
2020-09-29 02:20:32,277: Vulkan is supported
2020-09-29 02:20:33,394: Runtime icons is not available locally
2020-09-29 02:20:33,555: MAME XML written
2020-09-29 02:20:40,535: Non existent path: /var/home/deathwish/.var/app/net.lutris.Lutris/data/lutris/runtime/icons
2020-09-29 02:20:42,659: Runtime updated
```
Some packages were updated, some of the following https://github.com/flathub/flathub/pull/1830.

**NOTE:** I can't currently test if games run on this since I don't have my desktop machine *any more*. I am marking as a WIP until this gets more testing.