### PR TITLE
Add Steam Utility extension point

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ To compile Lutris as a Flatpak, you'll need both [Flatpak](https://flatpak.org/)
    flatpak install --user lutris net.lutris.Lutris
    ```
 
+### MangoHud
+
+To enable MangoHud support simply install
+
+```
+flatpak install flathub com.valvesoftware.Steam.Utility.MangoHud
+```
+
 ### Clean up
 
 ```sh

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -56,6 +56,16 @@ add-extensions:
     no-autodownload: true
     autodelete: true
 
+  com.valvesoftware.Steam.Utility:
+    subdirectories: true
+    directory: utils
+    version: beta
+    versions: stable;beta;test
+    add-ld-path: lib
+    merge-dirs: share/vulkan/explicit_layer.d;share/vulkan/implicit_layer.d;
+    no-autodownload: true
+    autodelete: true
+
 sdk-extensions:
   - org.gnome.Sdk.Compat.i386
   - org.freedesktop.Sdk.Extension.toolchain-i386
@@ -639,6 +649,9 @@ modules:
       - mkdir -p /app/lib/i386-linux-gnu
       - install -Dm644 ld.so.conf -t /app/etc/
       - mkdir -p /app/runners
+      - mkdir -p /app/utils /app/share/ /app/share/vulkan
+      - ln -srv /app/{utils/,}share/vulkan/implicit_layer.d
+      - ln -srv /app/{utils/,}share/vulkan/explicit_layer.d
     sources:
       - type: file
         path: ld.so.conf

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -26,7 +26,7 @@ finish-args:
   - --persist=.wine
   - --filesystem=xdg-data/Steam:ro
   - --filesystem=~/.var/app/com.valvesoftware.Steam:ro
-  - --env=PATH=/app/bin:/app/runners/bin:/usr/bin
+  - --env=PATH=/app/bin:/app/runners/bin:/usr/bin:/app/utils/bin
 add-extensions:
   org.gnome.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
@@ -62,7 +62,7 @@ add-extensions:
     version: beta
     versions: stable;beta;test
     add-ld-path: lib
-    merge-dirs: share/vulkan/explicit_layer.d;share/vulkan/implicit_layer.d;
+    merge-dirs: bin;share/vulkan/explicit_layer.d;share/vulkan/implicit_layer.d;
     no-autodownload: true
     autodelete: true
 


### PR DESCRIPTION
Fixes: https://github.com/flathub/net.lutris.Lutris/issues/103

TODO: This has to be revisited in the future. A patch to Lutris is required to detect the Vulkan extension instead of the binary.