### PR TITLE
Do not auto delete Steam Utilities

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -64,7 +64,6 @@ add-extensions:
     add-ld-path: lib
     merge-dirs: bin;share/vulkan/explicit_layer.d;share/vulkan/implicit_layer.d;
     no-autodownload: true
-    autodelete: true
 
 sdk-extensions:
   - org.gnome.Sdk.Compat.i386


### PR DESCRIPTION
When uninstalling net.lutris.Lutris. Since steams depends on this, this
could silently break user installations. A small testing had shown that
this is not the case when deleting lutris, but was the case when
deleting steam, removing it to be sure.