### PR TITLE
Temporarily fix wayland support 

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -27,6 +27,7 @@ finish-args:
   - --filesystem=xdg-data/Steam:ro
   - --filesystem=~/.var/app/com.valvesoftware.Steam:ro
   - --env=PATH=/app/bin:/app/runners/bin:/usr/bin:/app/utils/bin
+  - --env=GDK_BACKEND=x11
 add-extensions:
   org.gnome.Platform.Compat.i386:
     directory: lib/i386-linux-gnu


### PR DESCRIPTION
[This](https://github.com/lutris/agora/issues/63) issue is still present upstream, and this can fix it until there is a *real* fix there.

Simply set's backend as X11 (xwayland) rather than wayland (xfallback)