### PR TITLE
Add libxmu

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -527,6 +527,22 @@ modules:
     config-opts: *libcaca_config_opts
     sources: *libcaca_sources
 
+
+  - name: libxmu
+    config-opts: &libxmu_config_opts
+      - --disable-static
+    sources: &libxmu_sources
+      - type: archive
+        url: "https://xorg.freedesktop.org/releases/individual/lib/libXmu-1.1.3.tar.bz2"
+        sha512: 8c6cc65b22aa031ad870dd92736681a068a0878a425a53dbed909943da1136c4a24034d467cfd3785c3a8d78f66850b69f1ebe1eb24aaf9bc176b1d171a5c762
+
+  - name: libxmu-32bit
+    build-options:
+      arch:
+        x86_64: *compat_i386_opts
+    config-opts: *libxmu_config_opts
+    sources: *libxmu_sources
+
   # Standalone utilities
 
   - name: hwdata


### PR DESCRIPTION
As this is recommended to be installed locally when using Lutris as well as being included in the Steam runtime, I think it is safe to include.

Some games seem to require it for nVidia Optimus/Prime cards to work.

Closes #152