### PR TITLE
Add perl

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -716,3 +716,15 @@ modules:
     sources:
       - type: file
         path: ld.so.conf
+
+  - name: perl
+    sources:
+      - type: archive
+        url: "http://www.cpan.org/src/5.0/perl-5.32.0.tar.gz"
+        sha256: efeb1ce1f10824190ad1cadbcccf6fdb8a5d37007d0100d2d9ae5f2b5900c0b4
+      - type: script
+        dest-filename: configure
+        commands:
+          - ./Configure -des -Dprefix=/app
+    post-install:
+      - "find /app/lib/perl5 -type f -exec chmod u+w {} \\;"


### PR DESCRIPTION
I had to put the perl build at the and because other builds would try to use perl for their builds and fail because the perl install would be missing some xml parser.

Most of this was copied from here: https://github.com/flathub/io.github.Hexchat.Plugin.Perl/blob/master/io.github.Hexchat.Plugin.Perl.json#L15-L47