### PR TITLE
Add xterm

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -716,3 +716,21 @@ modules:
     sources:
       - type: file
         path: ld.so.conf
+
+  - name: xterm
+    no-autogen: true
+    sources:
+      - type: archive
+        url: "https://invisible-mirror.net/archives/xterm/xterm-368.tgz"
+        sha256: 2ff5169930b6b49ef0bafb5e1331c94f1a98c310442bba7798add821c76ae712
+    modules:
+      - name: libxaw
+        sources:
+          - type: archive
+            url: "https://xorg.freedesktop.org/releases/individual/lib/libXaw-1.0.14.tar.bz2"
+            sha256: 76aef98ea3df92615faec28004b5ce4e5c6855e716fa16de40c32030722a6f8e
+      - name: ncurses
+        sources:
+          - type: archive
+            url: "https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.2.tar.gz"
+            sha256: 30306e0c76e0f9f1f0de987cf1c82a5c21e1ce6568b9227f7da5b71cbea86c9d


### PR DESCRIPTION
This fixes the issue described in https://github.com/flathub/net.lutris.Lutris/issues/141

With this you can use the "Open Bash terminal" and "Run in a terminal" functionality of Lutris.
![image](https://user-images.githubusercontent.com/25890405/128884284-72652220-bcc0-40b3-9ca4-00e2cd734082.png)

![image](https://user-images.githubusercontent.com/25890405/128905216-18c01080-6d56-4a6c-b0dd-f956293ae77e.png)


I didn't go with the proposed gnome-terminal as it added more than 50 lines of code with all it's dependencies.