### PR TITLE
Add kitty terminal

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -728,3 +728,14 @@ modules:
           - ./Configure -des -Dprefix=/app
     post-install:
       - "find /app/lib/perl5 -type f -exec chmod u+w {} \\;"
+
+  - name: kitty
+    no-autogen: true
+    sources:
+      - type: git
+        url: "https://github.com/kovidgoyal/kitty"
+        tag: "v0.22.2"
+    no-make-install: true
+    post-install:
+      - "cp -r . $FLATPAK_DEST/lib/kitty"
+      - "ln -s /app/lib/kitty/kitty/launcher/kitty $FLATPAK_DEST/bin/kitty"


### PR DESCRIPTION
This fixes the issue described in [#141](https://github.com/flathub/net.lutris.Lutris/issues/141)

Updated to use kitty instead of xterm as described in https://github.com/flathub/net.lutris.Lutris/pull/164

@A6GibKm I tested the startup time of kitty and alacritty and couldn't find a relevant difference in startup time.
As kitty is way easier to include in this flatpak (alacritty has the rust dependency) I used it instead.