### PR TITLE
Install gamemoderun executable (Fixes v0.5.9)

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -501,6 +501,8 @@ modules:
       - -Dwith-examples=false
       - -Dwith-util=false
       - -Dwith-sd-bus-provider=no-daemon
+    post-install:
+      - install -Dm0775 -t /app/bin ../data/gamemoderun
     sources: &gamemode_sources
       - type: archive
         url: https://github.com/FeralInteractive/gamemode/releases/download/1.6.1/gamemode-1.6.1.tar.xz


### PR DESCRIPTION
The problem with lutris>=v0.5.9 is caused by the check for gamemode support:
https://github.com/lutris/lutris/blob/v0.5.9/lutris/util/linux.py#L208-L216

It returns True if the **gamemoderun** executable is available (not available in Flatpak) or the library **libgamemodeauto.so** is available (available in Flatpak).

When gamemode is supported it executes the **gamemoderun** executable (which fails):
https://github.com/lutris/lutris/blob/v0.5.9/lutris/runner_interpreter.py#L95-L98
