### PR TITLE
Add libfuse

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -14,11 +14,10 @@ finish-args:
   - --share=network
   - --allow=multiarch
   - --allow=devel
-  - --talk-name=org.freedesktop.Flatpak.*
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.gnome.Mutter.DisplayConfig
+  - --system-talk-name=org.freedesktop.UDisks2
   - --filesystem=~/Games:create
-  - --filesystem=/tmp
   - --filesystem=xdg-desktop
   - --filesystem=xdg-documents
   - --filesystem=xdg-pictures

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -14,9 +14,11 @@ finish-args:
   - --share=network
   - --allow=multiarch
   - --allow=devel
+  - --talk-name=org.freedesktop.Flatpak.*
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.gnome.Mutter.DisplayConfig
   - --filesystem=~/Games:create
+  - --filesystem=/tmp
   - --filesystem=xdg-desktop
   - --filesystem=xdg-documents
   - --filesystem=xdg-pictures
@@ -763,3 +765,21 @@ modules:
     post-install:
       - cp -r . $FLATPAK_DEST/lib/kitty
       - ln -s /app/lib/kitty/kitty/launcher/kitty $FLATPAK_DEST/bin/kitty
+  - name: fusermout
+    config-opts:
+      - MOUNT_FUSE_PATH=/app/bin
+    post-install:
+      - install fusermount-wrapper.sh /app/bin/fusermount
+    sources:
+      - type: archive
+        url: https://github.com/libfuse/libfuse/releases/download/fuse-2.9.9/fuse-2.9.9.tar.gz
+        sha256: d0e69d5d608cc22ff4843791ad097f554dd32540ddc9bed7638cc6fea7c1b4b5
+        x-checker-data:
+          type: anitya
+          project-id: 861
+          url-template: https://github.com/libfuse/libfuse/releases/download/fuse-$version/fuse-$version.tar.gz
+          versions: {<: '3'}
+      - type: patch
+        path: patches/fuse-2.9.2-namespace-conflict-fix.patch
+      - type: file
+        path: patches/fusermount-wrapper.sh

--- a/patches/fuse-2.9.2-namespace-conflict-fix.patch
+++ b/patches/fuse-2.9.2-namespace-conflict-fix.patch
@@ -1,0 +1,21 @@
+diff -up fuse-2.9.2/include/fuse_kernel.h.conflictfix fuse-2.9.2/include/fuse_kernel.h
+--- fuse-2.9.2/include/fuse_kernel.h.conflictfix	2013-06-26 09:31:57.862198038 -0400
++++ fuse-2.9.2/include/fuse_kernel.h	2013-06-26 09:32:19.679198365 -0400
+@@ -88,12 +88,16 @@
+ #ifndef _LINUX_FUSE_H
+ #define _LINUX_FUSE_H
+ 
+-#include <sys/types.h>
++#ifdef __linux__
++#include <linux/types.h>
++#else
++#include <stdint.h>
+ #define __u64 uint64_t
+ #define __s64 int64_t
+ #define __u32 uint32_t
+ #define __s32 int32_t
+ #define __u16 uint16_t
++#endif
+ 
+ /*
+  * Version negotiation:

--- a/patches/fusermount-wrapper.sh
+++ b/patches/fusermount-wrapper.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -z "$_FUSE_COMMFD" ]; then
+    FD_ARGS=
+else
+    FD_ARGS="--env=_FUSE_COMMFD=${_FUSE_COMMFD} --forward-fd=${_FUSE_COMMFD}"
+fi
+
+exec flatpak-spawn --host --forward-fd=1 --forward-fd=2 --forward-fd=3 $FD_ARGS fusermount "$@"


### PR DESCRIPTION
Closes https://github.com/flathub/net.lutris.Lutris/issues/200
Closes https://github.com/flathub/net.lutris.Lutris/issues/198
Closes https://github.com/flathub/net.lutris.Lutris/issues/12

This is mostly copied from https://github.com/flathub/org.gnome.World.PikaBackup/blob/master/org.gnome.World.PikaBackup.yml

It does use flatpak-spawn to acces fusermount on the host, meaning it punches another hole into the sandbox.