### PR TITLE
Add system-bus socket to the sandbox

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -10,6 +10,7 @@ finish-args:
   - --socket=x11
   - --socket=wayland
   - --socket=pulseaudio
+  - --socket=system-bus
   - --device=all
   - --share=network
   - --allow=multiarch


### PR DESCRIPTION
I can't launch the game [Warhammer Online: Return of Reckoning](https://www.returnofreckoning.com/) without this socket compared to the regular Lutris version.

I'm getting this error when I try to launch the game without it:

```
Failed to establish dbus connectionFailed to establish dbus connectiondbus[50]: arguments to dbus_connection_send_with_reply_and_block() were incorrect, assertion "connection != NULL" failed in file ../../dbus/dbus-connection.c line 3544.
This is normally a bug in some application using the D-Bus library.
```

I'm not exactly sure why and I don't know if this is safe or not or if there is an other way of doing it. Let me know if you want me to test anything else.