### PR TITLE
Added support for gamescope

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ To enable MangoHud support simply install
 flatpak install flathub org.freedesktop.Platform.VulkanLayer.MangoHud
 ```
 
+### Gamescope
+
+To enable Gamescope, install
+```
+flatpak install flathub com.valvesoftware.Steam.Utility.gamescope
+```
+
 ### Clean up
 
 ```sh
@@ -85,3 +92,6 @@ ___________________________________________
    ``` sh
    flatpak override --user --filesystem=/path/to/your/Folder net.lutris.Lutris
    ```
+- Gamescope isn't working
+
+   Disable Lutris Runtime for now since gamescope wouldn't run with it enabled.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ To enable Gamescope, install
 ```
 flatpak install flathub com.valvesoftware.Steam.Utility.gamescope
 ```
+If Gamescope isn't working disable the Lutris Runtime since wouldn't run with it enabled.
+
 
 ### Clean up
 

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -26,7 +26,7 @@ finish-args:
   - --persist=.wine
   - --filesystem=xdg-data/Steam:ro
   - --filesystem=~/.var/app/com.valvesoftware.Steam:ro
-  - --env=PATH=/app/bin:/app/runners/bin:/usr/bin:/usr/lib/extensions/vulkan/MangoHud/bin/
+  - --env=PATH=/app/bin:/app/runners/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/MangoHud/bin/
 add-extensions:
   org.gnome.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
@@ -48,6 +48,16 @@ add-extensions:
     merge-dirs: vulkan/icd.d;glvnd/egl_vendor.d;OpenCL/vendors;lib/dri;lib/d3d;vulkan/explicit_layer.d
     download-if: active-gl-driver
     enable-if: active-gl-driver
+    
+  com.valvesoftware.Steam.Utility:
+    subdirectories: true
+    directory: utils
+    version: stable
+    versions: stable;beta;test
+    add-ld-path: lib
+    merge-dirs: bin
+    no-autodownload: true
+    autodelete: true
 
   net.lutris.Lutris.Runner:
     directory: runners
@@ -76,6 +86,7 @@ cleanup:
   - /share/help
 cleanup-commands:
   - python3 -m compileall /app/lib
+  - mkdir -p /app/utils
 modules:
 
   - name: lutris


### PR DESCRIPTION
Note: Lutris Runtime needs to be disabled for gamescope to run. Based from the recent commits in [Bottles](https://github.com/flathub/com.usebottles.bottles).