### PR TITLE
Added shared-modules/libcanberra/libcanberra.json

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -82,6 +82,7 @@ cleanup-commands:
 modules:
   - modules/qt5-15.yaml
   - modules/libbz2-1.0.8.json
+  - shared-modules/libcanberra/libcanberra.json
   - name: vulkan-tools
     buildsystem: cmake-ninja
     config-opts:


### PR DESCRIPTION
Added shared-modules/libcanberra/libcanberra.json. Start up of net.lutris.Lutris would report missing support. Example warning:

```bash
➜  ~ 
> flatpak run net.lutris.Lutris 
Gtk-Message: 07:23:19.666: Failed to load module "canberra-gtk-module"
2022-05-28 07:23:19,668: Starting Lutris 0.5.10.1
2022-05-28 07:23:19,700: No folder at /var/home/filbot/.var/app/net.lutris.Lutris/data/lutris/runners/retroarch/
2022-05-28 07:23:19,726: Using NVIDIA drivers 510.68.02 for x86_64
2022-05-28 07:23:19,726: GPU: NVIDIA GeForce RTX 2070 SUPER
2022-05-28 07:23:19,726: GPU: 10DE:1E84 3842:3071 (nvidia drivers)
2022-05-28 07:23:19,792: Startup complete
```