### PR TITLE
add env to make (some) appimages run

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -29,6 +29,8 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Flatpak
   - --filesystem=xdg-data/flatpak:ro
+  # Needed for appimages
+  - --env=APPIMAGE_EXTRACT_AND_RUN=1
 
 inherit-extensions:
   - org.freedesktop.Platform.GL32


### PR DESCRIPTION
With this, appimages can now run, some will need new deps added to run (like https://github.com/flathub/net.lutris.Lutris/issues/299), some will need some arguments added to run (like `--no-sandbox` for electron appimages), but it's better that having appimages not working at all.

Fixes: https://github.com/flathub/net.lutris.Lutris/issues/200