### PR TITLE
Update Lutris to v0.5.12-beta1

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -735,7 +735,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/lutris/lutris.git
-        commit: aa04aa58e6dde6213de4d1e4aea0f4d81067db6b
+        commit: 09feb408a5ecc69d5820fed61930e84bbd893c72
       - type: patch
         path: webkit-version.patch
     modules:


### PR DESCRIPTION
This is my attempt to finally update the Lutris Flatpak version. The PR changes the Lutris commit in the manifest to `09feb408a5ecc69d5820fed61930e84bbd893c72`, which corresponds to `v0.5.12-beta1`. I'm using this version on my Steam Deck and had no issues so far.