### PR TITLE
Add 'setxkbmap' dependency

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -413,6 +413,12 @@ modules:
         url: https://xorg.freedesktop.org/archive/individual/app/xrandr-1.5.1.tar.gz
         sha256: 7b99edb7970a1365eaf5bcaf552144e4dfc3ccf510c4abc08569849929fb366e
 
+  - name: setxkbmap
+    sources:
+      - type: archive
+        url: https://xorg.freedesktop.org/archive/individual/app/setxkbmap-1.3.3.tar.xz
+        sha256: b560c678da6930a0da267304fa3a41cc5df39a96a5e23d06f14984c87b6f587b
+
   - name: mesa-demos
     config-opts:
       - --without-glut


### PR DESCRIPTION
Prior to this change, setting 'Switch to US keyboard layout' in Preferences > global options would stop any game from starting due to setxkbmap binary missing from the flatpak container. This commit allows for this option to function under lutris flatpak.