### PR TITLE
Add org.freedesktop.ScreenSaver

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -12,6 +12,7 @@ finish-args:
   - --socket=x11
   - --socket=wayland
   - --socket=pulseaudio
+  - --socket=session-bus
   - --device=all
   - --share=network
   - --allow=multiarch

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -12,12 +12,12 @@ finish-args:
   - --socket=x11
   - --socket=wayland
   - --socket=pulseaudio
-  - --socket=session-bus
   - --device=all
   - --share=network
   - --allow=multiarch
   - --allow=devel
   - --talk-name=org.gnome.Mutter.DisplayConfig
+  - --talk-name=org.freedesktop.ScreenSaver
   - --system-talk-name=org.freedesktop.UDisks2
   - --filesystem=home
   - --filesystem=/run/media


### PR DESCRIPTION
On KDE Wayland, when "GameMode" is disabled but "Disable screen saver" is enabled, the screen saver will still be triggered when it isn't supposed to. This isn't an issue on GNOME Wayland.

Adding this socket should mitigate that. Haven't tested this on X11.