### PR TITLE
Utilize new gamescope Flatpak

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -23,7 +23,7 @@ finish-args:
   # For Debian
   - --filesystem=/media
   - --filesystem=~/.var/app/com.valvesoftware.Steam:ro
-  - --env=PATH=/app/bin:/usr/bin:/app/utils/bin:/usr/lib/extensions/vulkan/MangoHud/bin/:/app/jre/bin/
+  - --env=PATH=/app/bin:/usr/bin:/app/utils/bin:/usr/lib/extensions/vulkan/MangoHud/bin/:/app/jre/bin/:/usr/lib/extensions/vulkan/gamescope/bin
   - --env=GST_PLUGIN_SYSTEM_PATH=/app/lib32/gstreamer-1.0:/app/lib/gstreamer-1.0:/usr/lib/i386-linux-gnu/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0
   # System tray icon
   - --talk-name=org.kde.StatusNotifierWatcher
@@ -50,16 +50,6 @@ add-extensions:
     directory: lib/debug/lib/i386-linux-gnu
     version: '44'
     no-autodownload: true
-
-  com.valvesoftware.Steam.Utility:
-    subdirectories: true
-    directory: utils
-    version: stable
-    versions: stable;beta;test
-    add-ld-path: lib
-    merge-dirs: bin
-    no-autodownload: true
-    autodelete: true
 
 sdk-extensions:
   - org.gnome.Sdk.Compat.i386


### PR DESCRIPTION
(https://github.com/flathub/com.valvesoftware.Steam.Utility.gamescope) is now EOL and has moved to (https://github.com/flathub/org.freedesktop.Platform.VulkanLayer.gamescope)

This utilizes that new extension and removes the need for "Steam Utilities". AFAIK, the Steam Utilities was solely for the old gamescope.

It is important to note that the freedesktop gamescope utilizes a newer version of gamescope making this issue (https://github.com/lutris/lutris/issues/4908) relevant. Users installing Lutris and freedesktop gamescope will find the provided gamescope options useless or may brush it off as broken.