### PR TITLE
Remove libudev from Wine base app

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -85,6 +85,10 @@ cleanup-commands:
   - python3 -m compileall /app/lib
   - mkdir -p /app/utils
 modules:
+  - name: remove-wine-libudev
+    buildsystem: simple
+    build-commands:
+      - rm /app/lib{,32}/libudev.so*
   - modules/qt5-15.yaml
   - modules/libbz2-1.0.8.json
   - name: vulkan-tools


### PR DESCRIPTION
I have built and tested this branch and it does fix the Webkit issue. I did run a Wine game and it did still work, but I'm nonetheless a bit worried that this library is somehow load-bearing and removing it breaks all sort of obscure shit.

Fixes #364 

(Note: I had to remove kitty to get it to build locally; I didn't touch it in the comment because I guess I'm hoping it was just a fluke.)