### PR TITLE
Add support for HDR through Gamescope

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -21,6 +21,9 @@ finish-args:
   - --system-talk-name=org.freedesktop.UDisks2
   - --filesystem=home
   - --filesystem=/run/media
+  # For Steam Deck HDR support
+  - --env=LD_LIBRARY_PATH=/usr/lib/extensions/vulkan/gamescope/lib
+  - --filesystem=xdg-run/gamescope-0:ro
   # For Debian
   - --filesystem=/media
   - --filesystem=~/.var/app/com.valvesoftware.Steam:ro


### PR DESCRIPTION
The following two changes allowed Heroic Games Launcher Flatpak to support HDR on Steam Deck through Gamescope:
- https://github.com/flathub/com.heroicgameslauncher.hgl/pull/115/files
- https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3281#issuecomment-1886197178

So I have applied these two changes in the Lutris Flatpak manifest to see if we can get it working here.