### PR TITLE
Add Gamescope Flatpak as dependency

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -45,6 +45,7 @@ inherit-extensions:
   - org.freedesktop.Platform.GL32
   - org.freedesktop.Platform.ffmpeg-full
   - org.freedesktop.Platform.ffmpeg_full.i386
+  - org.freedesktop.Platform.VulkanLayer.gamescope
   - org.winehq.Wine.gecko
   - org.winehq.Wine.mono
   - org.winehq.Wine.DLLs


### PR DESCRIPTION
I am not sure if this is the correct way to do this, but my intention here is to add the Gamescope Flatpak (a runtime extension to org.freedesktop.Platform) as a dependency to Lutris Flatpak.

You need the Gamescope Flatpak to get Gamescope working inside Flatpak Lutris, including for HDR output on Steam Deck, and I think it's more user-friendly to force this to be installed rather than asking users to install manually.