### PR TITLE
fix small typo/grammar issue

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -33,7 +33,7 @@ finish-args:
   # System tray icon
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Flatpak
-  # Disable access to xdg-data/flatpak as it's causing an finish-args-unnecessary-xdg-data-access error.
+  # Disable access to xdg-data/flatpak as it's causing a finish-args-unnecessary-xdg-data-access error.
   # Flatpak talk API might be enough but this might break features like Steam games detection.
   # - --filesystem=xdg-data/flatpak:ro
   # Needed for appimages


### PR DESCRIPTION
`an` is only used for words that start with a vowel sound, and `finish` does not