### PR TITLE
Update net.lutris.Lutris.yml

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -745,7 +745,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/lutris/lutris.git
-        commit: 70adad87231e57b73c838bcd20f084f242d6ae4c
+        commit: d71a2d41525d4f3accf745fea5d303882890123c
     modules:
       - modules/python3-poetry.json
       - modules/python3-requests.yaml


### PR DESCRIPTION
Closes https://github.com/flathub/net.lutris.Lutris/issues/423. Also allows users to get protonfixes for games and ensure the wine prefix is setup.