### PR TITLE
Fix Flatpak Builder Linter Warnings

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -595,7 +595,7 @@ modules:
             url: https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v4.6.1/libslirp-v4.6.1.tar.gz
             sha256: 69ad4df0123742a29cc783b35de34771ed74d085482470df6313b6abeb799b11
       - name: munt
-        buildsystem: cmake
+        buildsystem: cmake-ninja
         config-opts:
           - -Dmunt_WITH_MT32EMU_SMF2WAV=FALSE
           - -Dmunt_WITH_MT32EMU_QT=FALSE


### PR DESCRIPTION
Closed #466 accidentally. This is the same PR, which fixes a Flatpak builder linting issue by replacing a plain `cmake` build with `cmake-ninja`.