### PR TITLE
Fix Custom Mouse Cursors

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -48,6 +48,8 @@ finish-args:
   # See: https://github.com/flathub/com.valvesoftware.Steam/commit/0538256facdb0837c33232bc65a9195a8a5bc750
   - --env=XDG_DATA_DIRS=/app/share:/usr/lib/extensions/vulkan/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share:/usr/lib/pressure-vessel/overrides/share
   - --allow=per-app-dev-shm
+  # Needed to inherit custom cursors & scaling
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 
 inherit-extensions:
   - org.freedesktop.Platform.GL32


### PR DESCRIPTION
Without this env variable Lutris doesn't inherit custom mouse cursors and their scaling which leads to a weird experience, where the cursor is different when hovering the Lutris window. This is a common fix for Flatpak packages.