### PR TITLE
Fix Tray Icon not Showing Up in Some Configurations

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -743,7 +743,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/lutris/lutris.git
-        commit: 9b77a020e8f2792067bd5758725e0f20f3193010
+        commit: f935de038dfbfd549927cd3a0fc90c243ef3d764
     modules:
       - modules/python3-poetry.json
       - modules/python3-requests.yaml

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -3,8 +3,6 @@ sdk: org.gnome.Sdk
 runtime: org.gnome.Platform
 runtime-version: "46"
 command: lutris-wrapper
-rename-icon: lutris
-copy-icon: true
 base: org.winehq.Wine
 base-version: stable-23.08
 finish-args:
@@ -448,7 +446,7 @@ modules:
         url: https://download.gnome.org/sources/zenity/3.41/zenity-3.41.0.tar.xz
         sha256: 19b676c3510e22badfcc3204062d432ba537402f5e0ae26128c0d90c954037e1
 
-  - shared-modules/libappindicator/libappindicator-gtk3-introspection-12.10.json
+  - shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json
 
   # Required by some 8/16-bit emulators
   - shared-modules/linux-audio/fluidsynth2.json

--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -743,7 +743,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/lutris/lutris.git
-        commit: 70adad87231e57b73c838bcd20f084f242d6ae4c
+        commit: 9b77a020e8f2792067bd5758725e0f20f3193010
     modules:
       - modules/python3-poetry.json
       - modules/python3-requests.yaml


### PR DESCRIPTION
This resolves the issue, that the tray icon doesn't work in some desktops due to the icon name technically not matching. It will need [this upstream PR](https://github.com/lutris/lutris/pull/5839) to be merged, before it solves the issue.

I think technically the switch to `libayatana-appindicator` might not be necessary, but since upstream supports it there is no reason not to, as Appindicator3 is mostly deprecated at this point and distros start dropping it. So, it's mostly a future-proofing change related to the tray icon.

Fixes: #461 