### PR TITLE
Update SDL12-Compat

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -551,13 +551,13 @@ modules:
       - cp -r . $FLATPAK_DEST/lib/kitty
       - ln -s /app/lib/kitty/kitty/launcher/kitty $FLATPAK_DEST/bin/kitty
 
-  # Needed by Quake 3
+  # Needed by Quake 3 and others
   - name: sdl12-compat
     buildsystem: cmake-ninja
     sources: &sdl12_compat_sources
       - type: archive
-        url: https://github.com/libsdl-org/sdl12-compat/archive/refs/tags/release-1.2.52.tar.gz
-        sha256: 5bd7942703575554670a8767ae030f7921a0ac3c5e2fd173a537b7c7a8599014
+        url: https://github.com/libsdl-org/sdl12-compat/archive/refs/tags/release-1.2.68.tar.gz
+        sha256: 63c6e4dcc1154299e6f363c872900be7f3dcb3e42b9f8f57e05442ec3d89d02d
 
   - name: sdl12-compat-32bit
     buildsystem: cmake-ninja


### PR DESCRIPTION
Since many more old games require on SDL12 today, it would be best to actually include the latest version.