### PR TITLE
fix: Update kitty and install bundled libpython3.12 for GNOME 49

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -580,10 +580,11 @@ modules:
     build-commands:
       - install -Dm0775 -t /app/bin bin/kitty
       - cp -rn lib/kitty-extensions /app/lib
+      - install -Dm0755 lib/libpython3.12.so.1.0 /app/lib/libpython3.12.so.1.0
     sources:
       - type: archive
-        url: https://github.com/kovidgoyal/kitty/releases/download/v0.35.2/kitty-0.35.2-x86_64.txz
-        sha256: a49bb1ecd05495178a50958960a6377db6bbbfbe647b5c5ecae9bd14ded93acc
+        url: https://github.com/kovidgoyal/kitty/releases/download/v0.45.0/kitty-0.45.0-x86_64.txz
+        sha256: e6b70867a9a35181796775c79ebfbd82e00cf18c38b2bbdad73ff48d362380da
         strip-components: 0
 
   # Needed by Quake 3 and others


### PR DESCRIPTION
## Summary
- Updated kitty from v0.35.2 to v0.45.0 (latest)
- Added install of bundled `libpython3.12.so.1.0` to `/app/lib/`, which the kitty binary requires via its `RPATH ($ORIGIN/../lib)`
- The GNOME 49 runtime ships Python 3.13, so `libpython3.12.so.1.0` is not available in the runtime — the prebuilt kitty binary silently fails to start, breaking "Open Bash Terminal"

Fixes lutris/lutris#6467

## Test plan
- [ ] Build the Flatpak with the updated manifest
- [ ] Launch Lutris Flatpak, select a Wine game, and click "Open Bash Terminal" — a kitty terminal should open
- [ ] Verify `flatpak run --command=kitty net.lutris.Lutris` launches kitty without `libpython3.12.so.1.0` errors