### PR TITLE
Update Lutris to 0.5.21

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -580,10 +580,11 @@ modules:
     build-commands:
       - install -Dm0775 -t /app/bin bin/kitty
       - cp -rn lib/kitty-extensions /app/lib
+      - install -Dm0755 lib/libpython3.12.so.1.0 /app/lib/libpython3.12.so.1.0
     sources:
       - type: archive
-        url: https://github.com/kovidgoyal/kitty/releases/download/v0.35.2/kitty-0.35.2-x86_64.txz
-        sha256: a49bb1ecd05495178a50958960a6377db6bbbfbe647b5c5ecae9bd14ded93acc
+        url: https://github.com/kovidgoyal/kitty/releases/download/v0.45.0/kitty-0.45.0-x86_64.txz
+        sha256: e6b70867a9a35181796775c79ebfbd82e00cf18c38b2bbdad73ff48d362380da
         strip-components: 0
 
   # Needed by Quake 3 and others
@@ -790,7 +791,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/lutris/lutris.git
-        commit: c45a98a42b71b799d7169abd6ef3bd25f0065f9b
+        commit: 9781657d4eb2c3965c2ee27ae9d662a1d220a279
     modules:
       - modules/maturin.json
       - modules/python3-requests.yaml


### PR DESCRIPTION
## Summary
- Update Lutris to 0.5.21
- Update kitty to v0.45.0
- Install bundled libpython3.12 for GNOME 49 compatibility

Syncs master with beta branch content.