### PR TITLE
Update Lutris to 0.5.22

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -791,7 +791,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/lutris/lutris.git
-        commit: 9781657d4eb2c3965c2ee27ae9d662a1d220a279
+        commit: 159d7a21e5f171b815328e7e85aa40cfc3125ac8
     modules:
       - modules/maturin.json
       - modules/python3-requests.yaml


### PR DESCRIPTION
This is to `master`, but the `beta` is over at https://github.com/flathub/net.lutris.Lutris/pull/526 ... Do we do beta first?