### PR TITLE
Update requests and dependencies for Python 3.13 compatibility

### DIFF
--- a/modules/python3-requests.yaml
+++ b/modules/python3-requests.yaml
@@ -4,8 +4,8 @@ build-commands:
   - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
 sources:
   - type: archive
-    url: https://files.pythonhosted.org/packages/a5/61/a867851fd5ab77277495a8709ddda0861b28163c4613b011bc00228cc724/requests-2.28.1.tar.gz
-    sha256: 7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983
+    url: https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz
+    sha256: dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf
 modules:
   - name: python-urllib3
     buildsystem: simple
@@ -13,29 +13,29 @@ modules:
       - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
     sources:
       - type: archive
-        url: https://files.pythonhosted.org/packages/b2/56/d87d6d3c4121c0bcec116919350ca05dc3afd2eeb7dc88d07e8083f8ea94/urllib3-1.26.12.tar.gz
-        sha256: 3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e
+        url: https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz
+        sha256: 1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed
   - name: python-charset-normalizer
     buildsystem: simple
     build-commands:
       - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
     sources:
       - type: archive
-        url: https://files.pythonhosted.org/packages/a1/34/44964211e5410b051e4b8d2869c470ae8a68ae274953b1c7de6d98bbcf94/charset-normalizer-2.1.1.tar.gz
-        sha256: 5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845
+        url: https://files.pythonhosted.org/packages/2d/e8/1e60ebc3896fb15e9d8ffc13e53c7dd7a65f3ba7af4d9a1e28e0ef6a2a25/charset_normalizer-3.4.5.tar.gz
+        sha256: 4167a621a9a1a986c73777dbc15d4b5eac8ac5c10393374109a343d4013ec765
   - name: python-certifi
     buildsystem: simple
     build-commands:
       - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
     sources:
       - type: archive
-        url: https://files.pythonhosted.org/packages/ca/48/88ec470f8b68319b6782ca3a0570789886ad5ca24c1af2f3771699135baa/certifi-2022.9.14.tar.gz
-        sha256: 36973885b9542e6bd01dea287b2b4b3b21236307c56324fcc3f1160f2d655ed5
+        url: https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz
+        sha256: e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7
   - name: python-idna
     buildsystem: simple
     build-commands:
       - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
     sources:
       - type: archive
-        url: https://files.pythonhosted.org/packages/8b/e1/43beb3d38dba6cb420cefa297822eac205a277ab43e5ba5d5c46faf96438/idna-3.4.tar.gz
-        sha256: 814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4
+        url: https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz
+        sha256: 795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902

--- a/modules/python3-requests.yaml
+++ b/modules/python3-requests.yaml
@@ -1,41 +1,41 @@
 name: python-requests
 buildsystem: simple
 build-commands:
-  - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
+  - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" *.whl
 sources:
-  - type: archive
-    url: https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz
-    sha256: dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf
+  - type: file
+    url: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
+    sha256: 2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6
 modules:
   - name: python-urllib3
     buildsystem: simple
     build-commands:
-      - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
+      - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" *.whl
     sources:
-      - type: archive
-        url: https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz
-        sha256: 1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed
+      - type: file
+        url: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
+        sha256: bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
   - name: python-charset-normalizer
     buildsystem: simple
     build-commands:
-      - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
+      - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" *.whl
     sources:
-      - type: archive
-        url: https://files.pythonhosted.org/packages/2d/e8/1e60ebc3896fb15e9d8ffc13e53c7dd7a65f3ba7af4d9a1e28e0ef6a2a25/charset_normalizer-3.4.5.tar.gz
-        sha256: 4167a621a9a1a986c73777dbc15d4b5eac8ac5c10393374109a343d4013ec765
+      - type: file
+        url: https://files.pythonhosted.org/packages/c5/60/3a621758945513adfd4db86827a5bafcc615f913dbd0b4c2ed64a65731be/charset_normalizer-3.4.5-py3-none-any.whl
+        sha256: 9db5e3fcdcee89a78c04dffb3fe33c79f77bd741a624946db2591c81b2fc85b0
   - name: python-certifi
     buildsystem: simple
     build-commands:
-      - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
+      - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" *.whl
     sources:
-      - type: archive
-        url: https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz
-        sha256: e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7
+      - type: file
+        url: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
+        sha256: 027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa
   - name: python-idna
     buildsystem: simple
     build-commands:
-      - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" .
+      - pip3 install --no-index --no-build-isolation --prefix="${FLATPAK_DEST}" *.whl
     sources:
-      - type: archive
-        url: https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz
-        sha256: 795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902
+      - type: file
+        url: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
+        sha256: 771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea


### PR DESCRIPTION
This is Claude output, which I am trying to test- but I do not understand Flatpak well, so there may be problems. I've managed to build this beast locally and it seems to work and have updated libraries, for what that's worth.

In any case, I've verified that we're using a urllib3 is too old for Python 3.13. Hope this helps!

## Summary
- Updates all Python dependencies in modules/python3-requests.yaml to current versions and to be .whl files, to avoid needing hatchling' for urllib3.
- The previously bundled urllib3 1.26.12 is incompatible with Python 3.13 (GNOME runtime 49). It seemed to work much of the time anyway, ~~but see https://github.com/lutris/lutris/issues/6536~~.
- But the user tried it and this did not fix that issue 6536.
- It did work for him as a normal install, just not as an "extra flatpak install", so it seems to work as well as the last release does.

### Updated packages

| Package | Old | New |
|---|---|---|
| requests | 2.28.1 | 2.32.5 |
| urllib3 | 1.26.12 | 2.6.3 |
| charset-normalizer | 2.1.1 | 3.4.5 |
| certifi | 2022.9.14 | 2026.2.25 |
| idna | 3.4 | 3.11 |

All packages require Python >=3.9 and are compatible with GNOME runtime 49.

Does not help with: https://github.com/lutris/lutris/issues/6536

🤖 Generated with [Claude Code](https://claude.com/claude-code)