### PR TITLE
Update net.lutris.Lutris.yml

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -42,6 +42,7 @@ finish-args:
   # Install the umu runtime at $HOST_XDG_DATA_HOME
   # See: https://github.com/Open-Wine-Components/umu-launcher/pull/229
   - --filesystem=xdg-data/umu:create
+  - --filesystem=xdg-data/Steam:create
   # Pressure Vessel
   # See: https://github.com/flathub/com.valvesoftware.Steam/commit/0538256facdb0837c33232bc65a9195a8a5bc750
   - --env=XDG_DATA_DIRS=/app/share:/usr/lib/extensions/vulkan/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share:/usr/lib/pressure-vessel/overrides/share


### PR DESCRIPTION
Resolves an issue downloading and finding Proton-GE, if `--filesystem=home` is not set/disallowed. Logically consistent with the previous inclusion of `--filesystem=xdg-data/umu:create`.