### PR TITLE
Update net.lutris.Lutris.yml

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -18,6 +18,7 @@ finish-args:
   - --talk-name=org.freedesktop.ScreenSaver
   - --system-talk-name=org.freedesktop.UDisks2
   - --filesystem=home
+  - --filesystem=xdg-cache/lutris:create
   - --filesystem=/run/media
   # For Steam Deck HDR support
   - --env=LD_LIBRARY_PATH=/usr/lib/extensions/vulkan/gamescope/lib


### PR DESCRIPTION
Similar to https://github.com/flathub/net.lutris.Lutris/pull/531, ought to enable Lutris' basic functioning, even with `--filesystem=home` manually disabled.