### PR TITLE
Update net.lutris.Lutris.yml

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -18,6 +18,7 @@ finish-args:
   - --talk-name=org.freedesktop.ScreenSaver
   - --system-talk-name=org.freedesktop.UDisks2
   - --filesystem=home
+  - --filesystem=~/Games
   - --filesystem=/run/media
   # For Steam Deck HDR support
   - --env=LD_LIBRARY_PATH=/usr/lib/extensions/vulkan/gamescope/lib


### PR DESCRIPTION
Default location of games storage. Hopefully this covers remaining use-cases for `--filesystem=home`'s enablement?