### PR TITLE
Add dconf permissions to fix dark theme propagation

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -19,6 +19,13 @@ finish-args:
   - --system-talk-name=org.freedesktop.UDisks2
   - --filesystem=home
   - --filesystem=/run/media
+  # Allow reading host dconf settings for theme/color-scheme propagation.
+  # Needed as a fallback on desktop environments where xdg-desktop-portal
+  # does not provide org.freedesktop.appearance.color-scheme.
+  # See: https://github.com/lutris/lutris/issues/6499
+  - --talk-name=ca.desrt.dconf
+  - --filesystem=xdg-run/dconf:ro
+  - --env=DCONF_USER_CONFIG_DIR=.config/dconf
   # For Steam Deck HDR support
   - --env=LD_LIBRARY_PATH=/usr/lib/extensions/vulkan/gamescope/lib
   - --filesystem=xdg-run/gamescope-0:ro


### PR DESCRIPTION
## Summary
- Adds `--talk-name=ca.desrt.dconf`, `--filesystem=xdg-run/dconf:ro`, and `--env=DCONF_USER_CONFIG_DIR=.config/dconf` to `finish-args`
- Enables GTK3's native dconf integration as a fallback for reading the host's color-scheme preference when the freedesktop Settings portal doesn't provide it
- Fixes dark theme not being applied on desktop environments where the portal backend lacks `org.freedesktop.appearance.color-scheme` support (e.g. KDE, XFCE)

## Context
Lutris's `StyleManager` reads `color-scheme` via `org.freedesktop.portal.Settings`, which works on GNOME but may not be available on all desktop environments. Without dconf access, GTK3 inside the sandbox can't fall back to reading `org.gnome.desktop.interface.color-scheme` from the host's dconf, so the app always appears in light mode regardless of the user's system theme.

This is the same approach used by other Flatpak apps targeting broad DE support (e.g. GNOME Boxes). All access is read-only.

There is also a potential upstream bug in `lutris/style_manager.py` where `_read_value()` compares a `GLib.Variant` directly against Python ints, which may silently fail — but that fix belongs in the [Lutris repo](https://github.com/lutris/lutris).

## Test plan
- [ ] Install the Flatpak build on a system with dark theme enabled
- [ ] Verify Lutris respects the system dark theme on GNOME
- [ ] Verify Lutris respects the system dark theme on KDE/XFCE/other DEs
- [ ] Verify the Lutris preferences "Theme" dropdown still works (System Default / Light / Dark)

Fixes https://github.com/lutris/lutris/issues/6499