### PR TITLE
Test: Update Lutris commit to fix dark theme

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -791,7 +791,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/lutris/lutris.git
-        commit: 159d7a21e5f171b815328e7e85aa40cfc3125ac8
+        commit: a198ff6b68e762a247ce6c23c5213f2c420e25f4
     modules:
       - modules/maturin.json
       - modules/python3-requests.yaml


### PR DESCRIPTION
## Summary
- Updates Lutris commit to include the dark theme fix from https://github.com/lutris/lutris/pull/6557
- Test build to verify the fix works in Flatpak specifically

## What changed upstream
Two bugs in `StyleManager` prevented dark theme from working:
1. Init guard clause skipped `_update_is_dark()` entirely (class default matched init value)
2. Portal variant unpacking: `GLib.Variant` compared against Python ints always failed

## Test plan
- [ ] Install test Flatpak build
- [ ] Verify dark theme applies on startup with system dark theme
- [ ] Verify theme preference dropdown works (System Default / Light / Dark)
- [ ] Test on GNOME and KDE

Fixes https://github.com/lutris/lutris/issues/6499