### PR TITLE
Add Adwaita-dark GTK3 theme as auto-downloaded extension

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -68,6 +68,11 @@ add-extensions:
     autodelete: false
     add-ld-path: lib
 
+  org.gtk.Gtk3theme.Adwaita-dark:
+    directory: share/themes/Adwaita-dark
+    version: '3.22'
+    autodownload: true
+
 sdk-extensions:
   - org.freedesktop.Sdk.Compat.i386
   - org.freedesktop.Sdk.Extension.toolchain-i386
@@ -93,6 +98,7 @@ cleanup-commands:
   - python3 -m compileall /app/lib
   - mkdir -p /app/utils
   - mkdir -p /app/lib/i386-linux-gnu/codecs-extra
+  - mkdir -p /app/share/themes/Adwaita-dark
 modules:
   - modules/qt5-15.yaml
   - modules/libbz2-1.0.8.json


### PR DESCRIPTION
## Summary
- Adds `org.gtk.Gtk3theme.Adwaita-dark` as an auto-downloaded extension so the dark theme variant is always available inside the sandbox
- Creates the mount point directory in cleanup-commands

## Context
Follow-up to #535. Even with the StyleManager fix merged, some environments may not have the Adwaita dark CSS available inside the Flatpak sandbox. Auto-downloading the theme extension ensures `gtk-application-prefer-dark-theme` has a dark variant to use.

## Test plan
- [ ] Verify the extension is auto-installed when installing/updating the Flatpak
- [ ] Verify dark theme works without manually running `flatpak install org.gtk.Gtk3theme.Adwaita-dark`

Ref: https://github.com/lutris/lutris/issues/6499