### PR TITLE
Add gamescope and MangoHud as auto-downloaded extensions

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -68,6 +68,17 @@ add-extensions:
     autodelete: false
     add-ld-path: lib
 
+  org.freedesktop.Platform.VulkanLayer.gamescope:
+    directory: lib/extensions/vulkan/gamescope
+    version: '25.08'
+    autodownload: true
+    autodelete: false
+
+  org.freedesktop.Platform.VulkanLayer.MangoHud:
+    directory: lib/extensions/vulkan/MangoHud
+    version: '25.08'
+    autodownload: true
+    autodelete: false
 sdk-extensions:
   - org.freedesktop.Sdk.Compat.i386
   - org.freedesktop.Sdk.Extension.toolchain-i386
@@ -92,6 +103,8 @@ cleanup:
 cleanup-commands:
   - python3 -m compileall /app/lib
   - mkdir -p /app/utils
+  - mkdir -p /app/lib/extensions/vulkan/gamescope
+  - mkdir -p /app/lib/extensions/vulkan/MangoHud
   - mkdir -p /app/lib/i386-linux-gnu/codecs-extra
 modules:
   - modules/qt5-15.yaml


### PR DESCRIPTION
## Summary
- Adds `org.freedesktop.Platform.VulkanLayer.gamescope` and `org.freedesktop.Platform.VulkanLayer.MangoHud` as auto-downloaded extensions (25.08 branch, matching the GNOME 49 runtime)
- Users will no longer need to manually install the correct gamescope/MangoHud extension or figure out the right branch
- Tested with Lutris flatpak on GNOME 49 runtime — gamescope launches and wraps games correctly with the 25.08 VulkanLayer extension

## Test plan
- [ ] Install Lutris flatpak fresh and verify gamescope and MangoHud extensions are auto-downloaded
- [ ] Enable gamescope for a game and verify it works (game renders inside gamescope window)
- [ ] Enable MangoHud and verify the overlay appears

Fixes #514, #346, #342, #271