### PR TITLE
Add filesystem access for Discord Flatpak IPC socket

### DIFF
--- a/net.lutris.Lutris.yml
+++ b/net.lutris.Lutris.yml
@@ -22,6 +22,9 @@ finish-args:
   # For Steam Deck HDR support
   - --env=LD_LIBRARY_PATH=/usr/lib/extensions/vulkan/gamescope/lib
   - --filesystem=xdg-run/gamescope-0:ro
+  # For Discord Rich Presence (Flatpak Discord)
+  - --filesystem=xdg-run/app/com.discordapp.Discord:create
+  - --filesystem=xdg-run/app/com.discordapp.DiscordCanary:create
   # For Debian
   - --filesystem=/media
   - --filesystem=~/.var/app/com.valvesoftware.Steam:ro


### PR DESCRIPTION
## Summary
- Adds `--filesystem=xdg-run/app/com.discordapp.Discord:create` and `DiscordCanary` variant to `finish-args`
- Allows Lutris to connect to Discord Rich Presence when both Lutris and Discord are installed as Flatpaks
- Flatpak Discord exposes its IPC socket via a socat relay at `$XDG_RUNTIME_DIR/app/com.discordapp.Discord/discord-ipc-0`, which pypresence already knows to check — but the Lutris sandbox couldn't see the directory

Fixes https://github.com/lutris/lutris/issues/6588

## Test plan
- [x] Verified Discord Flatpak creates socket at `$XDG_RUNTIME_DIR/app/com.discordapp.Discord/discord-ipc-0`
- [x] Built Lutris Flatpak with this change and confirmed socket is visible inside the sandbox
- [x] Confirmed Discord Rich Presence works end-to-end (Far Cry showing in Discord status)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>